### PR TITLE
Bypass allowed content types contraint when (post)install messagesConfig container.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 0.21 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Bypass allowed content types contraint when (post)install messagesConfig container
+  [boulch]
 
 
 0.20 (2019-08-23)

--- a/src/collective/messagesviewlet/setuphandlers.py
+++ b/src/collective/messagesviewlet/setuphandlers.py
@@ -4,6 +4,7 @@ from collective.messagesviewlet import HAS_PLONE_5
 from plone import api
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone import interfaces as Plone
 from utils import _
 from utils import add_message
@@ -20,16 +21,12 @@ def post_install(context):
     site = context.getSite()
 
     if not site.get(FOLDER):
-        types = getToolByName(site, 'portal_types')
-        types.getTypeInfo('MessagesConfig').global_allow = True
-        container = api.content.create(site,
-                                       "MessagesConfig",
-                                       id=FOLDER,
-                                       title=_('Messages viewlet settings', context=site)
-                                       )
+        container = _createObjectByType('MessagesConfig',
+                            container=site,
+                            id=FOLDER,
+                            title=_('Messages viewlet settings', context=site))
         excl = IExcludeFromNavigation(container)
         excl.exclude_from_nav = True
-        types.getTypeInfo('MessagesConfig').global_allow = False
 
 
 @implementer(Plone.INonInstallable)


### PR DESCRIPTION

Messagesviewlet must be install even if there are some allowed content types constraints on PloneSite portal type.